### PR TITLE
Add type for validation + parsing functionality

### DIFF
--- a/src/App.fs
+++ b/src/App.fs
@@ -14,7 +14,7 @@ open Lib.Validations
 [<ReactComponent>]
 let TextField
     (props: {| label: string
-               field: Field<string> |})
+               field: Field<string, string> |})
     =
     Mui.textField [
         prop.style [ style.minHeight 80 ]
@@ -36,8 +36,8 @@ let TextField
 
 [<ReactComponent>]
 let App () =
-    let nameField = Hooks.useField ("", [ requiredString; minLength 10 ])
-    let nicknameField = Hooks.useField ("", [ requiredString; minLength 3 ])
+    let nameField = Hooks.useField ("", Some, [ requiredString; minLength 10 ])
+    let nicknameField = Hooks.useField ("", Some, [ requiredString; minLength 3 ])
 
     Html.div [
 

--- a/src/Lib/UI/Form.fs
+++ b/src/Lib/UI/Form.fs
@@ -8,8 +8,8 @@ type FormProperty =
     interface
     end
 
-type FormProps<'a> =
-    abstract fields: Field<'a> list option
+type FormProps<'a, 'b> =
+    abstract fields: Field<'a, 'b> list option
     abstract onSubmit: (Browser.Types.Event -> unit) option
     abstract children: list<ReactElement> option
 
@@ -17,10 +17,10 @@ type FormProps<'a> =
 [<AutoOpen>]
 module private Core =
     let mkAttr (key: string) (value: 'a) : FormProperty = unbox (key, value)
-    let unboxProperties (properties: FormProperty list) : FormProps<'a> = !!properties |> createObj |> unbox
+    let unboxProperties (properties: FormProperty list) : FormProps<'a, 'b> = !!properties |> createObj |> unbox
 
 type form =
-    static member fields(xs: Field<'a> list) : FormProperty = mkAttr "fields" xs
+    static member fields(xs: Field<'a, 'b> list) : FormProperty = mkAttr "fields" xs
     static member onSubmit(fn: Browser.Types.Event -> unit) : FormProperty = mkAttr "onSubmit" fn
     static member children(xs: ReactElement list) : FormProperty = mkAttr "children" xs
 
@@ -29,7 +29,7 @@ type UI =
     [<ReactComponent>]
     static member form(properties: FormProperty list) : ReactElement =
 
-        let form (props: FormProps<'a>) =
+        let form (props: FormProps<'a, 'b>) =
             let fields = Option.defaultValue [] props.fields
             let onSubmit = Option.defaultValue ignore props.onSubmit
             let children = Option.defaultValue [] props.children

--- a/src/Lib/Validations.fs
+++ b/src/Lib/Validations.fs
@@ -1,11 +1,15 @@
 module Lib.Validations
 
-type validation<'a> = 'a -> bool * string
+type Validation<'a> =
+    | NonValid of 'a
+    | Valid
+
+type validationFunc<'a> = 'a -> Validation<'a>
+
+type parseFunc<'a, 'b> = 'a -> option<'b>
 
 let requiredString input =
-    let isValid = input <> ""
-    (isValid, "This field is required")
+    if input <> "" then Valid else NonValid "É obrigatório o preenchimento deste campo"
 
 let minLength length (input: string) =
-    let isValid = input.Length >= length
-    (isValid, sprintf "This field should contain at least %d characters" length)
+    if input.Length >= length then Valid else NonValid (sprintf "This field should contain at least %d characters" length)


### PR DESCRIPTION
This MR adds two features:
- The ability to do parsing using the custom hook. Although you can achieve parsing by exploring a lot of validations, this is, as we already talked about, removing the weight and security from the type system and adding it to the validation system. So, I decided to maintain this contribution.
- A new type for validation functions, instead of using a tuple. The tuple is enough, but I always recommend to use and to abuse the type system. Makes it safer and more intuitive.